### PR TITLE
ExceptionController's debug is now twig.options.debug, not a kernel.debug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ CHANGELOG
  * added support for multiple loaders via the "twig.loader" tag.
  * added automatic registration of namespaced paths for registered bundles
  * added support for namespaced paths
+ * ExceptionController's `debug` is now twig.options.debug, not kernel.debug
 
 2.1.0
 -----

--- a/Controller/ExceptionController.php
+++ b/Controller/ExceptionController.php
@@ -27,10 +27,10 @@ class ExceptionController
     protected $twig;
     protected $debug;
 
-    public function __construct(\Twig_Environment $twig, $debug)
+    public function __construct(\Twig_Environment $twig, array $twigOptions)
     {
         $this->twig = $twig;
-        $this->debug = $debug;
+        $this->debug = isset($twigOptions['debug']) ? $twigOptions['debug'] : false;
     }
 
     /**

--- a/Resources/config/twig.xml
+++ b/Resources/config/twig.xml
@@ -121,7 +121,7 @@
 
         <service id="twig.controller.exception" class="%twig.controller.exception.class%">
             <argument type="service" id="twig" />
-            <argument>%kernel.debug%</argument>
+            <argument>%twig.options%</argument>
         </service>
     </services>
 </container>


### PR DESCRIPTION
| Q | A |
| --- | --- |
| Bug fix? | yes |
| New feature? | no |
| BC breaks? | no |
| Deprecations? | no |
| Tests pass? | yes |
| License | MIT |

TwigBundle exposes configuration setting `debug` which is by default equal to `%kernel.debug%`.
This value can be overridden, but Twig's built-in ExceptionController always uses `%kernel.debug%` instead of `twig.oprions['debug']` so overriding does not affect it.
See e.g. [this question on StackOverflow](http://stackoverflow.com/questions/16833201/symfony-2-get-error-instead-of-debug-page-on-test-environment-how-to-set-deb)
I faced this problem when tried to write tests for my custom 404 page. I set twig.debug to "false" in config_test.yml, but it still displayed stacktrace info instead of my custom 404 page
