### PR TITLE
Updating twig version requirement to ^2.14 (vulnerability)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "symfony/http-kernel": "^4.4",
         "symfony/polyfill-ctype": "~1.8",
         "symfony/polyfill-php80": "^1.16",
-        "twig/twig": "^1.43|^2.13|^3.0.4"
+        "twig/twig": "^1.43|^2.14|^3.0.4"
     },
     "require-dev": {
         "symfony/asset": "^3.4|^4.0|^5.0",


### PR DESCRIPTION
https://symfony.com/blog/twig-security-release-disallow-non-closures-in-the-sort-filter

```
Symfony Security Check Report
=============================

1 package has known vulnerabilities.

twig/twig (v2.13.1)
-------------------

 * [CVE-2022-23614][]: Disallow non closures in the sort filter

[CVE-2022-23614]: https://symfony.com/blog/twig-security-release-disallow-non-closures-in-the-sort-filter

Note that this checker can only detect vulnerabilities that are referenced in the security advisories database.
Execute this command regularly to check the newly discovered vulnerabilities.
```