### PR TITLE
Twig Vulnerability Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "symfony/http-foundation": "^5.4|^6.0",
         "symfony/http-kernel": "^5.4|^6.0",
         "symfony/polyfill-ctype": "~1.8",
-        "twig/twig": "^2.13|^3.0.4"
+        "twig/twig": "^2.15.3|^3.4.3"
     },
     "require-dev": {
         "symfony/asset": "^5.4|^6.0",


### PR DESCRIPTION
Based on https://github.com/advisories/GHSA-52m2-vc4m-jj33 twig/twig needs a bump to 1.44.7, 2.15.3, 3.4.3